### PR TITLE
Disable power save app suspension

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const window = require('electron-window')
 const getOptions = require('mocha/bin/options')
 const args = require('./args')
 const mocha = require('./mocha')
-const { app, ipcMain: ipc } = require('electron')
+const { app, ipcMain: ipc, powerSaveBlocker } = require('electron')
 const { spawn } = require('child_process')
 
 // load mocha.opts into process.argv
@@ -43,6 +43,7 @@ app.on('quit', () => {
 app.on('window-all-closed', () => {})
 
 app.on('ready', () => {
+  powerSaveBlocker.start('prevent-app-suspension')
   if (opts.interactive) {
     opts.renderer = true
     opts.debug = true


### PR DESCRIPTION
Long running tests or test that need to wait for a given time could lead to the OS suspend the app or reduce its cpu time.
This leads to lesser precision for `setTimeout` or `setInterval` execution.